### PR TITLE
staging/ion: condition unmapped heap to supported architectures

### DIFF
--- a/drivers/staging/android/ion/Kconfig
+++ b/drivers/staging/android/ion/Kconfig
@@ -45,7 +45,7 @@ config ION_CMA_HEAP
 
 config ION_UNMAPPED_HEAP
 	bool "ION unmapped heap support"
-	depends on ION
+	depends on ION && ARM
 	help
 	  Choose this option to enable UNMAPPED heaps with Ion. This heap is
 	  backed in specific memory pools, carveout from the Linux memory.


### PR DESCRIPTION
Condition ION unmapped heap implementation to architectures that
currently support it. ARM is one of these.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>