### PR TITLE
staging:ion: add a no-map property to ion dmabuf attachment

### DIFF
--- a/drivers/staging/android/ion/ion.c
+++ b/drivers/staging/android/ion/ion.c
@@ -218,6 +218,7 @@ struct ion_dma_buf_attachment {
 	struct device *dev;
 	struct sg_table *table;
 	struct list_head list;
+	bool no_map;
 };
 
 static int ion_dma_buf_attach(struct dma_buf *dmabuf, struct device *dev,
@@ -236,6 +237,9 @@ static int ion_dma_buf_attach(struct dma_buf *dmabuf, struct device *dev,
 		kfree(a);
 		return -ENOMEM;
 	}
+
+	if (buffer->heap->type == ION_HEAP_TYPE_UNMAPPED)
+		a->no_map = true;
 
 	a->table = table;
 	a->dev = dev;
@@ -274,6 +278,9 @@ static struct sg_table *ion_map_dma_buf(struct dma_buf_attachment *attachment,
 
 	table = a->table;
 
+	if (a->no_map)
+		return table;
+
 	if (!dma_map_sg(attachment->dev, table->sgl, table->nents,
 			direction)){
 		ret = -ENOMEM;
@@ -290,6 +297,11 @@ static void ion_unmap_dma_buf(struct dma_buf_attachment *attachment,
 			      struct sg_table *table,
 			      enum dma_data_direction direction)
 {
+	struct ion_dma_buf_attachment *a = attachment->priv;
+
+	if (a->no_map)
+		return;
+
 	dma_unmap_sg(attachment->dev, table->sgl, table->nents, direction);
 }
 


### PR DESCRIPTION
Ion unmapped heap aims at not being mapped. This change prevents
Ion from calling dma-mapping support on dma_buf_attach for buffers
in an unmapped heap.

This change is a bit intrusive in the Ion driver. Maybe there is
another way to deal with the dma-mapping resources used for the
unmapped heap.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>
Tested-by: Etienne Carriere <etienne.carriere@linaro.org> (qemu_virt, qemu_armv8)